### PR TITLE
Fixed coffeescript syntax in top example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cd 'lib'
 for file in ls '*.js'
   sed '-i', 'BUILD_VERSION', 'v0.1.2', file
   sed '-i', /.*REMOVE_THIS_LINE.*\n/, '', file
-  sed '-i', /.*REPLACE_LINE_WITH_MACRO.*\n/, cat 'macro.js', file
+  sed '-i', /.*REPLACE_LINE_WITH_MACRO.*\n/, cat('macro.js'), file
 cd '..'
 
 # Run external tool synchronously


### PR DESCRIPTION
The `cat 'macro.js'` needs parentesis to not include `file`. The current coffeescript compiles to the following:

```javascript
sed('-i', /.*REPLACE_LINE_WITH_MACRO.*\n/, cat('macro.js', file));
```