### PR TITLE
Allow to run make loop manually instead of a timeout

### DIFF
--- a/make.js
+++ b/make.js
@@ -5,9 +5,12 @@ global.target = {};
 
 // This ensures we only execute the script targets after the entire script has
 // been evaluated
-var args = process.argv.slice(2);
-setTimeout(function() {
+var args = process.argv.slice(2),
+  runOnce = 0;
+exports.run = function() {
   var t;
+
+  if (runOnce++) return;
 
   if (args.length === 1 && args[0] === '--help') {
     console.log('Available targets:');
@@ -44,4 +47,5 @@ setTimeout(function() {
     global.target.all();
   }
 
-}, 0);
+}
+setTimeout(exports.run, 0)


### PR DESCRIPTION
This allows using fibers-based flow control in make targets.
make.run() is always called only once. If you omit it, it will run at the end of the script as usual.

```
var Sync = require('sync'),
  // require shelljs/make at the beggining, but store the exports
  Make = require('shelljs/make') 

Sync(function() {
  target.all = function() {
    var result = asyncFunction.sync();
  }

  // run make targets now 
  Make.run()
})
```