### PR TITLE
Switch to using `process.platform` instead of `os.type`.

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -1,4 +1,3 @@
-var os = require('os');
 var fs = require('fs');
 var _ls = require('./ls');
 
@@ -16,7 +15,7 @@ var state = {
 };
 exports.state = state;
 
-var platform = os.type().match(/^Win/) ? 'win' : 'unix';
+var platform = process.platform === 'win32' ? 'win' : 'unix';
 exports.platform = platform;
 
 function log() {

--- a/src/cp.js
+++ b/src/cp.js
@@ -1,7 +1,6 @@
 var fs = require('fs');
 var path = require('path');
 var common = require('./common');
-var os = require('os');
 
 // Buffered file copy, synchronous
 // (Using readFileSync() + writeFileSync() could easily cause a memory overflow
@@ -73,7 +72,7 @@ function cpdirSyncRecursive(sourceDir, destDir, opts) {
       cpdirSyncRecursive(srcFile, destFile, opts);
     } else if (srcFileStat.isSymbolicLink()) {
       var symlinkFull = fs.readlinkSync(srcFile);
-      fs.symlinkSync(symlinkFull, destFile, os.platform() === "win32" ? "junction" : null);
+      fs.symlinkSync(symlinkFull, destFile, common.platform === 'win' ? 'junction' : null);
     } else {
       /* At this point, we've hit a file actually worth copying... so copy it on over. */
       if (fs.existsSync(destFile) && !opts.force) {

--- a/src/ln.js
+++ b/src/ln.js
@@ -1,7 +1,6 @@
 var fs = require('fs');
 var path = require('path');
 var common = require('./common');
-var os = require('os');
 
 //@
 //@ ### ln(options, source, dest)
@@ -45,9 +44,9 @@ function _ln(options, source, dest) {
   }
 
   if (options.symlink) {
-    fs.symlinkSync(source, dest, os.platform() === "win32" ? "junction" : null);
+    fs.symlinkSync(source, dest, common.platform === 'win' ? 'junction' : null);
   } else {
-    fs.linkSync(source, dest, os.platform() === "win32" ? "junction" : null);
+    fs.linkSync(source, dest, common.platform === 'win' ? 'junction' : null);
   }
 }
 module.exports = _ln;


### PR DESCRIPTION
Also, use `common.platform` everywhere.