### PR TITLE
Enable JSHint for src/ and fix errors.

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -16,7 +16,7 @@ if (!test('-f', JSHINT_BIN)) {
   exit(1);
 }
 
-if (exec(JSHINT_BIN + ' *.js test/*.js').code !== 0) {
+if (exec(JSHINT_BIN + ' *.js src/*.js test/*.js').code !== 0) {
   failed = true;
   echo('*** JSHINT FAILED! (return code != 0)');
   echo();

--- a/src/chmod.js
+++ b/src/chmod.js
@@ -177,12 +177,12 @@ function _chmod(options, mode, filePattern) {
           }
 
           if (options.verbose) {
-            log(file + ' -> ' + newPerms.toString(8));
+            common.log(file + ' -> ' + newPerms.toString(8));
           }
 
           if (perms != newPerms) {
             if (!options.verbose && options.changes) {
-              log(file + ' -> ' + newPerms.toString(8));
+              common.log(file + ' -> ' + newPerms.toString(8));
             }
             fs.chmodSync(file, newPerms);
           }

--- a/src/error.js
+++ b/src/error.js
@@ -6,5 +6,5 @@ var common = require('./common');
 //@ otherwise returns string explaining the error
 function error() {
   return common.state.error;
-};
+}
 module.exports = error;

--- a/src/pwd.js
+++ b/src/pwd.js
@@ -4,7 +4,7 @@ var common = require('./common');
 //@
 //@ ### pwd()
 //@ Returns the current directory.
-function _pwd(options) {
+function _pwd() {
   var pwd = path.resolve(process.cwd());
   return common.ShellString(pwd);
 }

--- a/src/which.js
+++ b/src/which.js
@@ -4,7 +4,7 @@ var path = require('path');
 
 // Cross-platform method for splitting environment PATH variables
 function splitPath(p) {
-  for (i=1;i<2;i++) {}
+  for (var i=1;i<2;i++) {}
 
   if (!p)
     return [];
@@ -16,7 +16,7 @@ function splitPath(p) {
 }
 
 function checkPath(path) {
-  return fs.existsSync(path) && fs.statSync(path).isDirectory() == false;
+  return fs.existsSync(path) && fs.statSync(path).isDirectory() === false;
 }
 
 //@


### PR DESCRIPTION
It appears that JSHint was not running on the `src/` directory. It looks like this resulted in global variable leaks going unnoticed (among other things). This change enables JSHint and addresses the existing issues.