### PR TITLE
Add existsSync module that works on node 0.6

### DIFF
--- a/src/cat.js
+++ b/src/cat.js
@@ -1,5 +1,6 @@
 var common = require('./common');
 var fs = require('fs');
+var existsSync = require('./existsSync');
 
 //@
 //@ ### cat(file [, file ...])
@@ -29,7 +30,7 @@ function _cat(options, files) {
   files = common.expand(files);
 
   files.forEach(function(file) {
-    if (!fs.existsSync(file))
+    if (!existsSync(file))
       common.error('no such file or directory: ' + file);
 
     cat += fs.readFileSync(file, 'utf8') + '\n';

--- a/src/cd.js
+++ b/src/cd.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var common = require('./common');
+var existsSync = require('./existsSync');
 
 //@
 //@ ### cd('dir')
@@ -8,7 +9,7 @@ function _cd(options, dir) {
   if (!dir)
     common.error('directory not specified');
 
-  if (!fs.existsSync(dir))
+  if (!existsSync(dir))
     common.error('no such file or directory: ' + dir);
 
   if (!fs.statSync(dir).isDirectory())

--- a/src/chmod.js
+++ b/src/chmod.js
@@ -1,6 +1,7 @@
 var common = require('./common');
 var fs = require('fs');
 var path = require('path');
+var existsSync = require('./existsSync');
 
 var PERMS = (function (base) {
   return {
@@ -105,7 +106,7 @@ function _chmod(options, mode, filePattern) {
 
   files.forEach(function innerChmod(file) {
     file = path.resolve(file);
-    if (!fs.existsSync(file)) {
+    if (!existsSync(file)) {
       common.error('File not found: ' + file);
     }
 

--- a/src/cp.js
+++ b/src/cp.js
@@ -2,12 +2,13 @@ var fs = require('fs');
 var path = require('path');
 var common = require('./common');
 var os = require('os');
+var existsSync = require('./existsSync');
 
 // Buffered file copy, synchronous
 // (Using readFileSync() + writeFileSync() could easily cause a memory overflow
 //  with large files)
 function copyFileSync(srcFile, destFile) {
-  if (!fs.existsSync(srcFile))
+  if (!existsSync(srcFile))
     common.error('copyFileSync: no such file or directory: ' + srcFile);
 
   var BUF_LENGTH = 64*1024,
@@ -76,7 +77,7 @@ function cpdirSyncRecursive(sourceDir, destDir, opts) {
       fs.symlinkSync(symlinkFull, destFile, os.platform() === "win32" ? "junction" : null);
     } else {
       /* At this point, we've hit a file actually worth copying... so copy it on over. */
-      if (fs.existsSync(destFile) && !opts.force) {
+      if (existsSync(destFile) && !opts.force) {
         common.log('skipping existing file: ' + files[i]);
       } else {
         copyFileSync(srcFile, destFile);
@@ -125,7 +126,7 @@ function _cp(options, sources, dest) {
     common.error('invalid arguments');
   }
 
-  var exists = fs.existsSync(dest),
+  var exists = existsSync(dest),
       stats = exists && fs.statSync(dest);
 
   // Dest is not existing dir, but multiple sources given
@@ -155,7 +156,7 @@ function _cp(options, sources, dest) {
   sources = common.expand(sources);
 
   sources.forEach(function(src) {
-    if (!fs.existsSync(src)) {
+    if (!existsSync(src)) {
       common.error('no such file or directory: '+src, true);
       return; // skip file
     }
@@ -190,10 +191,10 @@ function _cp(options, sources, dest) {
     // When copying to '/path/dir':
     //    thisDest = '/path/dir/file1'
     var thisDest = dest;
-    if (fs.existsSync(dest) && fs.statSync(dest).isDirectory())
+    if (existsSync(dest) && fs.statSync(dest).isDirectory())
       thisDest = path.normalize(dest + '/' + path.basename(src));
 
-    if (fs.existsSync(thisDest) && !options.force) {
+    if (existsSync(thisDest) && !options.force) {
       common.error('dest file already exists: ' + thisDest, true);
       return; // skip file
     }

--- a/src/exec.js
+++ b/src/exec.js
@@ -4,6 +4,7 @@ var _pwd = require('./pwd');
 var path = require('path');
 var fs = require('fs');
 var child = require('child_process');
+var existsSync = require('./existsSync');
 
 // Hack to run child_process.exec() synchronously (sync avoids callback hell)
 // Uses a custom wait loop that checks for a flag file, created when the child process is done.
@@ -24,7 +25,7 @@ function execSync(cmd, opts) {
   var previousStdoutContent = '';
   // Echoes stdout changes from running process, if not silent
   function updateStdout() {
-    if (options.silent || !fs.existsSync(stdoutFile))
+    if (options.silent || !existsSync(stdoutFile))
       return;
 
     var stdoutContent = fs.readFileSync(stdoutFile, 'utf8');
@@ -49,9 +50,9 @@ function execSync(cmd, opts) {
    "  fs.writeFileSync('"+escape(codeFile)+"', err ? err.code.toString() : '0');" +
    "});";
 
-  if (fs.existsSync(scriptFile)) common.unlinkSync(scriptFile);
-  if (fs.existsSync(stdoutFile)) common.unlinkSync(stdoutFile);
-  if (fs.existsSync(codeFile)) common.unlinkSync(codeFile);
+  if (existsSync(scriptFile)) common.unlinkSync(scriptFile);
+  if (existsSync(stdoutFile)) common.unlinkSync(stdoutFile);
+  if (existsSync(codeFile)) common.unlinkSync(codeFile);
 
   fs.writeFileSync(scriptFile, script);
   child.exec('"'+process.execPath+'" '+scriptFile, {
@@ -64,8 +65,8 @@ function execSync(cmd, opts) {
   // sleepFile is used as a dummy I/O op to mitigate unnecessary CPU usage
   // (tried many I/O sync ops, writeFileSync() seems to be only one that is effective in reducing
   // CPU usage, though apparently not so much on Windows)
-  while (!fs.existsSync(codeFile)) { updateStdout(); fs.writeFileSync(sleepFile, 'a'); }
-  while (!fs.existsSync(stdoutFile)) { updateStdout(); fs.writeFileSync(sleepFile, 'a'); }
+  while (!existsSync(codeFile)) { updateStdout(); fs.writeFileSync(sleepFile, 'a'); }
+  while (!existsSync(stdoutFile)) { updateStdout(); fs.writeFileSync(sleepFile, 'a'); }
 
   // At this point codeFile exists, but it's not necessarily flushed yet.
   // Keep reading it until it is.

--- a/src/existsSync.js
+++ b/src/existsSync.js
@@ -1,0 +1,4 @@
+var fs = require('fs');
+var path = require('path');
+
+module.exports = fs.existsSync || path.existsSync;

--- a/src/grep.js
+++ b/src/grep.js
@@ -1,5 +1,6 @@
 var common = require('./common');
 var fs = require('fs');
+var existsSync = require('./existsSync');
 
 //@
 //@ ### grep([options ,] regex_filter, file [, file ...])
@@ -33,7 +34,7 @@ function _grep(options, regex, files) {
 
   var grep = '';
   files.forEach(function(file) {
-    if (!fs.existsSync(file)) {
+    if (!existsSync(file)) {
       common.error('no such file or directory: ' + file, true);
       return;
     }

--- a/src/ln.js
+++ b/src/ln.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var common = require('./common');
 var os = require('os');
+var existsSync = require('./existsSync');
 
 //@
 //@ ### ln(options, source, dest)
@@ -32,11 +33,11 @@ function _ln(options, source, dest) {
   source = path.resolve(process.cwd(), String(source));
   dest = path.resolve(process.cwd(), String(dest));
 
-  if (!fs.existsSync(source)) {
+  if (!existsSync(source)) {
     common.error('Source file does not exist', true);
   }
 
-  if (fs.existsSync(dest)) {
+  if (existsSync(dest)) {
     if (!options.force) {
       common.error('Destination file exists', true);
     }

--- a/src/ls.js
+++ b/src/ls.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var common = require('./common');
 var _cd = require('./cd');
 var _pwd = require('./pwd');
+var existsSync = require('./existsSync');
 
 //@
 //@ ### ls([options ,] path [,path ...])
@@ -63,7 +64,7 @@ function _ls(options, paths) {
   }
 
   paths.forEach(function(p) {
-    if (fs.existsSync(p)) {
+    if (existsSync(p)) {
       var stats = fs.statSync(p);
       // Simple file?
       if (stats.isFile()) {
@@ -96,7 +97,7 @@ function _ls(options, paths) {
     var basename = path.basename(p);
     var dirname = path.dirname(p);
     // Wildcard present on an existing dir? (e.g. '/tmp/*.js')
-    if (basename.search(/\*/) > -1 && fs.existsSync(dirname) && fs.statSync(dirname).isDirectory) {
+    if (basename.search(/\*/) > -1 && existsSync(dirname) && fs.statSync(dirname).isDirectory) {
       // Escape special regular expression chars
       var regexp = basename.replace(/(\^|\$|\(|\)|<|>|\[|\]|\{|\}|\.|\+|\?)/g, '\\$1');
       // Translates wildcard into regex

--- a/src/mkdir.js
+++ b/src/mkdir.js
@@ -1,13 +1,14 @@
 var common = require('./common');
 var fs = require('fs');
 var path = require('path');
+var existsSync = require('./existsSync');
 
 // Recursively creates 'dir'
 function mkdirSyncRecursive(dir) {
   var baseDir = path.dirname(dir);
 
   // Base dir exists, no recursion necessary
-  if (fs.existsSync(baseDir)) {
+  if (existsSync(baseDir)) {
     fs.mkdirSync(dir, parseInt('0777', 8));
     return;
   }
@@ -46,7 +47,7 @@ function _mkdir(options, dirs) {
   // if it's array leave it as it is
 
   dirs.forEach(function(dir) {
-    if (fs.existsSync(dir)) {
+    if (existsSync(dir)) {
       if (!options.fullpath)
           common.error('path already exists: ' + dir, true);
       return; // skip dir
@@ -54,7 +55,7 @@ function _mkdir(options, dirs) {
 
     // Base dir does not exist, and no -p option given
     var baseDir = path.dirname(dir);
-    if (!fs.existsSync(baseDir) && !options.fullpath) {
+    if (!existsSync(baseDir) && !options.fullpath) {
       common.error('no such file or directory: ' + baseDir, true);
       return; // skip dir
     }

--- a/src/mv.js
+++ b/src/mv.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 var common = require('./common');
+var existsSync = require('./existsSync');
 
 //@
 //@ ### mv(source [, source ...], dest')
@@ -39,7 +40,7 @@ function _mv(options, sources, dest) {
 
   sources = common.expand(sources);
 
-  var exists = fs.existsSync(dest),
+  var exists = existsSync(dest),
       stats = exists && fs.statSync(dest);
 
   // Dest is not existing dir, but multiple sources given
@@ -51,7 +52,7 @@ function _mv(options, sources, dest) {
     common.error('dest file already exists: ' + dest);
 
   sources.forEach(function(src) {
-    if (!fs.existsSync(src)) {
+    if (!existsSync(src)) {
       common.error('no such file or directory: '+src, true);
       return; // skip file
     }
@@ -61,10 +62,10 @@ function _mv(options, sources, dest) {
     // When copying to '/path/dir':
     //    thisDest = '/path/dir/file1'
     var thisDest = dest;
-    if (fs.existsSync(dest) && fs.statSync(dest).isDirectory())
+    if (existsSync(dest) && fs.statSync(dest).isDirectory())
       thisDest = path.normalize(dest + '/' + path.basename(src));
 
-    if (fs.existsSync(thisDest) && !options.force) {
+    if (existsSync(thisDest) && !options.force) {
       common.error('dest file already exists: ' + thisDest, true);
       return; // skip file
     }

--- a/src/rm.js
+++ b/src/rm.js
@@ -1,5 +1,6 @@
 var common = require('./common');
 var fs = require('fs');
+var existsSync = require('./existsSync');
 
 // Recursively removes 'dir'
 // Adapted from https://github.com/ryanmcgrath/wrench-js
@@ -103,7 +104,7 @@ function _rm(options, files) {
   files = common.expand(files);
 
   files.forEach(function(file) {
-    if (!fs.existsSync(file)) {
+    if (!existsSync(file)) {
       // Path does not exist, no force flag given
       if (!options.force)
         common.error('no such file or directory: '+file, true);

--- a/src/sed.js
+++ b/src/sed.js
@@ -1,5 +1,6 @@
 var common = require('./common');
 var fs = require('fs');
+var existsSync = require('./existsSync');
 
 //@
 //@ ### sed([options ,] search_regex, replacement, file)
@@ -31,7 +32,7 @@ function _sed(options, regex, replacement, file) {
   if (!file)
     common.error('no file given');
 
-  if (!fs.existsSync(file))
+  if (!existsSync(file))
     common.error('no such file or directory: ' + file);
 
   var result = fs.readFileSync(file, 'utf8').replace(regex, replacement);

--- a/src/tempdir.js
+++ b/src/tempdir.js
@@ -1,10 +1,11 @@
 var common = require('./common');
 var os = require('os');
 var fs = require('fs');
+var existsSync = require('./existsSync');
 
 // Returns false if 'dir' is not a writeable directory, 'dir' otherwise
 function writeableDir(dir) {
-  if (!dir || !fs.existsSync(dir))
+  if (!dir || !existsSync(dir))
     return false;
 
   if (!fs.statSync(dir).isDirectory())

--- a/src/test.js
+++ b/src/test.js
@@ -1,5 +1,6 @@
 var common = require('./common');
 var fs = require('fs');
+var existsSync = require('./existsSync');
 
 //@
 //@ ### test(expression)
@@ -56,7 +57,7 @@ function _test(options, path) {
     }
   }
 
-  if (!fs.existsSync(path))
+  if (!existsSync(path))
     return false;
 
   if (options.exists)

--- a/src/to.js
+++ b/src/to.js
@@ -1,6 +1,7 @@
 var common = require('./common');
 var fs = require('fs');
 var path = require('path');
+var existsSync = require('./existsSync');
 
 //@
 //@ ### 'string'.to(file)
@@ -17,7 +18,7 @@ function _to(options, file) {
   if (!file)
     common.error('wrong arguments');
 
-  if (!fs.existsSync( path.dirname(file) ))
+  if (!existsSync( path.dirname(file) ))
       common.error('no such file or directory: ' + path.dirname(file));
 
   try {

--- a/src/toEnd.js
+++ b/src/toEnd.js
@@ -1,6 +1,7 @@
 var common = require('./common');
 var fs = require('fs');
 var path = require('path');
+var existsSync = require('./existsSync');
 
 //@
 //@ ### 'string'.toEnd(file)
@@ -17,7 +18,7 @@ function _toEnd(options, file) {
   if (!file)
     common.error('wrong arguments');
 
-  if (!fs.existsSync( path.dirname(file) ))
+  if (!existsSync( path.dirname(file) ))
       common.error('no such file or directory: ' + path.dirname(file));
 
   try {

--- a/src/which.js
+++ b/src/which.js
@@ -1,6 +1,7 @@
 var common = require('./common');
 var fs = require('fs');
 var path = require('path');
+var existsSync = require('./existsSync');
 
 // Cross-platform method for splitting environment PATH variables
 function splitPath(p) {
@@ -16,7 +17,7 @@ function splitPath(p) {
 }
 
 function checkPath(path) {
-  return fs.existsSync(path) && fs.statSync(path).isDirectory() == false;
+  return existsSync(path) && fs.statSync(path).isDirectory() == false;
 }
 
 //@

--- a/test/cat.js
+++ b/test/cat.js
@@ -1,7 +1,7 @@
 var shell = require('..');
 
-var assert = require('assert'),
-    fs = require('fs');
+var assert = require('assert');
+var existsSync = require('../src/existsSync');
 
 shell.config.silent = true;
 
@@ -15,7 +15,7 @@ shell.mkdir('tmp');
 shell.cat();
 assert.ok(shell.error());
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(existsSync('/asdfasdf'), false); // sanity check
 shell.cat('/adsfasdf'); // file does not exist
 assert.ok(shell.error());
 

--- a/test/cd.js
+++ b/test/cd.js
@@ -2,7 +2,7 @@ var shell = require('..');
 
 var assert = require('assert'),
     path = require('path'),
-    fs = require('fs');
+    existsSync = require('../src/existsSync');
 
 shell.config.silent = true;
 
@@ -19,11 +19,11 @@ shell.mkdir('tmp');
 shell.cd();
 assert.ok(shell.error());
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(existsSync('/asdfasdf'), false); // sanity check
 shell.cd('/adsfasdf'); // dir does not exist
 assert.ok(shell.error());
 
-assert.equal(fs.existsSync('resources/file1'), true); // sanity check
+assert.equal(existsSync('resources/file1'), true); // sanity check
 shell.cd('resources/file1'); // file, not dir
 assert.ok(shell.error());
 
@@ -45,13 +45,13 @@ assert.equal(process.cwd(), path.resolve('/'));
 
 shell.cd(cur);
 shell.rm('-f', 'tmp/*');
-assert.equal(fs.existsSync('tmp/file1'), false);
+assert.equal(existsSync('tmp/file1'), false);
 shell.cd('resources');
 assert.equal(shell.error(), null);
 shell.cp('file1', '../tmp');
 assert.equal(shell.error(), null);
 shell.cd('../tmp');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('file1'), true);
+assert.equal(existsSync('file1'), true);
 
 shell.exit(123);

--- a/test/cp.js
+++ b/test/cp.js
@@ -2,6 +2,7 @@ var shell = require('..');
 
 var assert = require('assert'),
     fs = require('fs');
+var existsSync = require('../src/existsSync');
 
 shell.config.silent = true;
 
@@ -28,22 +29,22 @@ assert.ok(shell.error());
 shell.rm('-rf', 'tmp/*');
 shell.cp('-@', 'resources/file1', 'tmp/file1'); // option not supported, files OK
 assert.ok(shell.error());
-assert.equal(fs.existsSync('tmp/file1'), false);
+assert.equal(existsSync('tmp/file1'), false);
 
 shell.cp('-Z', 'asdfasdf', 'tmp/file2'); // option not supported, files NOT OK
 assert.ok(shell.error());
-assert.equal(fs.existsSync('tmp/file2'), false);
+assert.equal(existsSync('tmp/file2'), false);
 
 shell.cp('asdfasdf', 'tmp'); // source does not exist
 assert.ok(shell.error());
 assert.equal(numLines(shell.error()), 1);
-assert.equal(fs.existsSync('tmp/asdfasdf'), false);
+assert.equal(existsSync('tmp/asdfasdf'), false);
 
 shell.cp('asdfasdf1', 'asdfasdf2', 'tmp'); // sources do not exist
 assert.ok(shell.error());
 assert.equal(numLines(shell.error()), 2);
-assert.equal(fs.existsSync('tmp/asdfasdf1'), false);
-assert.equal(fs.existsSync('tmp/asdfasdf2'), false);
+assert.equal(existsSync('tmp/asdfasdf1'), false);
+assert.equal(existsSync('tmp/asdfasdf2'), false);
 
 shell.cp('asdfasdf1', 'asdfasdf2', 'resources/file1'); // too many sources (dest is file)
 assert.ok(shell.error());
@@ -53,7 +54,7 @@ assert.ok(shell.error());
 
 shell.cp('resources/file1', 'resources/file2', 'tmp/a_file'); // too many sources
 assert.ok(shell.error());
-assert.equal(fs.existsSync('tmp/a_file'), false);
+assert.equal(existsSync('tmp/a_file'), false);
 
 //
 // Valids
@@ -62,39 +63,39 @@ assert.equal(fs.existsSync('tmp/a_file'), false);
 // simple - to dir
 shell.cp('resources/file1', 'tmp');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/file1'), true);
+assert.equal(existsSync('tmp/file1'), true);
 
 // simple - to file
 shell.cp('resources/file2', 'tmp/file2');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/file2'), true);
+assert.equal(existsSync('tmp/file2'), true);
 
 // simple - file list
 shell.rm('-rf', 'tmp/*');
 shell.cp('resources/file1', 'resources/file2', 'tmp');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/file1'), true);
-assert.equal(fs.existsSync('tmp/file2'), true);
+assert.equal(existsSync('tmp/file1'), true);
+assert.equal(existsSync('tmp/file2'), true);
 
 // simple - file list, array syntax
 shell.rm('-rf', 'tmp/*');
 shell.cp(['resources/file1', 'resources/file2'], 'tmp');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/file1'), true);
-assert.equal(fs.existsSync('tmp/file2'), true);
+assert.equal(existsSync('tmp/file1'), true);
+assert.equal(existsSync('tmp/file2'), true);
 
 shell.cp('resources/file2', 'tmp/file3');
-assert.equal(fs.existsSync('tmp/file3'), true);
+assert.equal(existsSync('tmp/file3'), true);
 shell.cp('-f', 'resources/file2', 'tmp/file3'); // file exists, but -f specified
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/file3'), true);
+assert.equal(existsSync('tmp/file3'), true);
 
 // wildcard
 shell.rm('tmp/file1', 'tmp/file2');
 shell.cp('resources/file*', 'tmp');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/file1'), true);
-assert.equal(fs.existsSync('tmp/file2'), true);
+assert.equal(existsSync('tmp/file1'), true);
+assert.equal(existsSync('tmp/file2'), true);
 
 //recursive, nothing exists
 shell.rm('-rf', 'tmp/*');
@@ -134,7 +135,7 @@ assert.equal(shell.cat('resources/issue44/main.js'), shell.cat('tmp/dir2/main.js
 shell.rm('-rf', 'tmp/*');
 shell.cp('-r', 'resources/issue44/*', 'tmp/dir2/dir3');
 assert.ok(shell.error());
-assert.equal(fs.existsSync('tmp/dir2'), false);
+assert.equal(existsSync('tmp/dir2'), false);
 
 //preserve mode bits
 shell.rm('-rf', 'tmp/*');

--- a/test/grep.js
+++ b/test/grep.js
@@ -1,7 +1,7 @@
 var shell = require('..');
 
-var assert = require('assert'),
-    fs = require('fs');
+var assert = require('assert');
+var existsSync = require('../src/existsSync');
 
 shell.config.silent = true;
 
@@ -18,7 +18,7 @@ assert.ok(shell.error());
 shell.grep(/asdf/g); // too few args
 assert.ok(shell.error());
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(existsSync('/asdfasdf'), false); // sanity check
 shell.grep(/asdf/g, '/asdfasdf'); // no such file
 assert.ok(shell.error());
 

--- a/test/ln.js
+++ b/test/ln.js
@@ -3,6 +3,7 @@ var shell = require('..');
 var assert = require('assert'),
     fs = require('fs'),
     path = require('path');
+var existsSync = require('../src/existsSync');
 
 shell.config.silent = true;
 
@@ -36,7 +37,7 @@ assert.ok(shell.error());
 //
 
 shell.ln('tmp/file1', 'tmp/linkfile1');
-assert(fs.existsSync('tmp/linkfile1'));
+assert(existsSync('tmp/linkfile1'));
 assert.equal(
   fs.readFileSync('tmp/file1').toString(),
   fs.readFileSync('tmp/linkfile1').toString()
@@ -48,7 +49,7 @@ assert.equal(
 );
 
 shell.ln('-s', 'tmp/file2', 'tmp/linkfile2');
-assert(fs.existsSync('tmp/linkfile2'));
+assert(existsSync('tmp/linkfile2'));
 assert.equal(
   fs.readFileSync('tmp/file2').toString(),
   fs.readFileSync('tmp/linkfile2').toString()
@@ -60,7 +61,7 @@ assert.equal(
 );
 
 shell.ln('-f', 'tmp/file1.js', 'tmp/file2.js');
-assert(fs.existsSync('tmp/file2.js'));
+assert(existsSync('tmp/file2.js'));
 assert.equal(
   fs.readFileSync('tmp/file1.js').toString(),
   fs.readFileSync('tmp/file2.js').toString()
@@ -72,7 +73,7 @@ assert.equal(
 );
 
 shell.ln('-sf', 'tmp/file1.txt', 'tmp/file2.txt');
-assert(fs.existsSync('tmp/file2.txt'));
+assert(existsSync('tmp/file2.txt'));
 assert.equal(
   fs.readFileSync('tmp/file1.txt').toString(),
   fs.readFileSync('tmp/file2.txt').toString()
@@ -85,7 +86,7 @@ assert.equal(
 
 // Abspath regression
 shell.ln('-sf', 'tmp/file1', path.resolve('tmp/abspath'));
-assert(fs.existsSync('tmp/abspath'));
+assert(existsSync('tmp/abspath'));
 assert.equal(
   fs.readFileSync('tmp/file1').toString(),
   fs.readFileSync('tmp/abspath').toString()

--- a/test/ls.js
+++ b/test/ls.js
@@ -1,7 +1,7 @@
 var shell = require('..');
 
-var assert = require('assert'),
-    fs = require('fs');
+var assert = require('assert');
+var existsSync = require('../src/existsSync');
 
 shell.config.silent = true;
 
@@ -12,7 +12,7 @@ shell.mkdir('tmp');
 // Invalids
 //
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(existsSync('/asdfasdf'), false); // sanity check
 var result = shell.ls('/asdfasdf'); // no such file or dir
 assert.ok(shell.error());
 assert.equal(result.length, 0);

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -2,6 +2,7 @@ var shell = require('..');
 
 var assert = require('assert'),
     fs = require('fs');
+var existsSync = require('../src/existsSync');
 
 shell.config.silent = true;
 
@@ -24,52 +25,52 @@ shell.mkdir('tmp'); // dir already exists
 assert.ok(shell.error());
 assert.equal(fs.statSync('tmp').mtime.toString(), mtime); // didn't mess with dir
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(existsSync('/asdfasdf'), false); // sanity check
 shell.mkdir('/asdfasdf/asdfasdf'); // root path does not exist
 assert.ok(shell.error());
-assert.equal(fs.existsSync('/asdfasdf'), false);
+assert.equal(existsSync('/asdfasdf'), false);
 
 //
 // Valids
 //
 
-assert.equal(fs.existsSync('tmp/t1'), false);
+assert.equal(existsSync('tmp/t1'), false);
 shell.mkdir('tmp/t1'); // simple dir
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/t1'), true);
+assert.equal(existsSync('tmp/t1'), true);
 
-assert.equal(fs.existsSync('tmp/t2'), false);
-assert.equal(fs.existsSync('tmp/t3'), false);
+assert.equal(existsSync('tmp/t2'), false);
+assert.equal(existsSync('tmp/t3'), false);
 shell.mkdir('tmp/t2', 'tmp/t3'); // multiple dirs
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/t2'), true);
-assert.equal(fs.existsSync('tmp/t3'), true);
+assert.equal(existsSync('tmp/t2'), true);
+assert.equal(existsSync('tmp/t3'), true);
 
-assert.equal(fs.existsSync('tmp/t1'), true);
-assert.equal(fs.existsSync('tmp/t4'), false);
+assert.equal(existsSync('tmp/t1'), true);
+assert.equal(existsSync('tmp/t4'), false);
 shell.mkdir('tmp/t1', 'tmp/t4'); // one dir exists, one doesn't
 assert.equal(numLines(shell.error()), 1);
-assert.equal(fs.existsSync('tmp/t1'), true);
-assert.equal(fs.existsSync('tmp/t4'), true);
+assert.equal(existsSync('tmp/t1'), true);
+assert.equal(existsSync('tmp/t4'), true);
 
-assert.equal(fs.existsSync('tmp/a'), false);
+assert.equal(existsSync('tmp/a'), false);
 shell.mkdir('-p', 'tmp/a/b/c');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/a/b/c'), true);
+assert.equal(existsSync('tmp/a/b/c'), true);
 shell.rm('-Rf', 'tmp/a'); // revert
 
 // multiple dirs
 shell.mkdir('-p', 'tmp/zzza', 'tmp/zzzb', 'tmp/zzzc');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/zzza'), true);
-assert.equal(fs.existsSync('tmp/zzzb'), true);
-assert.equal(fs.existsSync('tmp/zzzc'), true);
+assert.equal(existsSync('tmp/zzza'), true);
+assert.equal(existsSync('tmp/zzzb'), true);
+assert.equal(existsSync('tmp/zzzc'), true);
 
 // multiple dirs, array syntax
 shell.mkdir('-p', ['tmp/yyya', 'tmp/yyyb', 'tmp/yyyc']);
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/yyya'), true);
-assert.equal(fs.existsSync('tmp/yyyb'), true);
-assert.equal(fs.existsSync('tmp/yyyc'), true);
+assert.equal(existsSync('tmp/yyya'), true);
+assert.equal(existsSync('tmp/yyyb'), true);
+assert.equal(existsSync('tmp/yyyc'), true);
 
 shell.exit(123);

--- a/test/mv.js
+++ b/test/mv.js
@@ -1,7 +1,7 @@
 var shell = require('..');
 
-var assert = require('assert'),
-    fs = require('fs');
+var assert = require('assert');
+var existsSync = require('../src/existsSync');
 
 shell.config.silent = true;
 
@@ -30,18 +30,18 @@ assert.ok(shell.error());
 
 shell.mv('-Z', 'tmp/file1', 'tmp/file1'); // option not supported
 assert.ok(shell.error());
-assert.equal(fs.existsSync('tmp/file1'), true);
+assert.equal(existsSync('tmp/file1'), true);
 
 shell.mv('asdfasdf', 'tmp'); // source does not exist
 assert.ok(shell.error());
 assert.equal(numLines(shell.error()), 1);
-assert.equal(fs.existsSync('tmp/asdfasdf'), false);
+assert.equal(existsSync('tmp/asdfasdf'), false);
 
 shell.mv('asdfasdf1', 'asdfasdf2', 'tmp'); // sources do not exist
 assert.ok(shell.error());
 assert.equal(numLines(shell.error()), 2);
-assert.equal(fs.existsSync('tmp/asdfasdf1'), false);
-assert.equal(fs.existsSync('tmp/asdfasdf2'), false);
+assert.equal(existsSync('tmp/asdfasdf1'), false);
+assert.equal(existsSync('tmp/asdfasdf2'), false);
 
 shell.mv('asdfasdf1', 'asdfasdf2', 'tmp/file1'); // too many sources (dest is file)
 assert.ok(shell.error());
@@ -51,14 +51,14 @@ assert.ok(shell.error());
 
 shell.mv('tmp/file1', 'tmp/file2', 'tmp/a_file'); // too many sources (exist, but dest is file)
 assert.ok(shell.error());
-assert.equal(fs.existsSync('tmp/a_file'), false);
+assert.equal(existsSync('tmp/a_file'), false);
 
 shell.mv('tmp/file*', 'tmp/file1'); // can't use wildcard when dest is file
 assert.ok(shell.error());
-assert.equal(fs.existsSync('tmp/file1'), true);
-assert.equal(fs.existsSync('tmp/file2'), true);
-assert.equal(fs.existsSync('tmp/file1.js'), true);
-assert.equal(fs.existsSync('tmp/file2.js'), true);
+assert.equal(existsSync('tmp/file1'), true);
+assert.equal(existsSync('tmp/file2'), true);
+assert.equal(existsSync('tmp/file1.js'), true);
+assert.equal(existsSync('tmp/file2.js'), true);
 
 //
 // Valids
@@ -70,57 +70,57 @@ shell.cd('tmp');
 shell.mkdir('tmp2');
 shell.mv('*', 'tmp2'); // has to handle self (tmp2 --> tmp2) without throwing error
 assert.ok(shell.error()); // there's an error, but not fatal
-assert.equal(fs.existsSync('tmp2/file1'), true); // moved OK
+assert.equal(existsSync('tmp2/file1'), true); // moved OK
 shell.mv('tmp2/*', '.'); // revert
-assert.equal(fs.existsSync('file1'), true); // moved OK
+assert.equal(existsSync('file1'), true); // moved OK
 
 shell.mv('file1', 'file3'); // one source
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('file1'), false);
-assert.equal(fs.existsSync('file3'), true);
+assert.equal(existsSync('file1'), false);
+assert.equal(existsSync('file3'), true);
 shell.mv('file3', 'file1'); // revert
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('file1'), true);
+assert.equal(existsSync('file1'), true);
 
 // two sources
 shell.rm('-rf', 't');
 shell.mkdir('-p', 't');
 shell.mv('file1', 'file2', 't');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('file1'), false);
-assert.equal(fs.existsSync('file2'), false);
-assert.equal(fs.existsSync('t/file1'), true);
-assert.equal(fs.existsSync('t/file2'), true);
+assert.equal(existsSync('file1'), false);
+assert.equal(existsSync('file2'), false);
+assert.equal(existsSync('t/file1'), true);
+assert.equal(existsSync('t/file2'), true);
 shell.mv('t/*', '.'); // revert
-assert.equal(fs.existsSync('file1'), true);
-assert.equal(fs.existsSync('file2'), true);
+assert.equal(existsSync('file1'), true);
+assert.equal(existsSync('file2'), true);
 
 // two sources, array style
 shell.rm('-rf', 't');
 shell.mkdir('-p', 't');
 shell.mv(['file1', 'file2'], 't'); // two sources
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('file1'), false);
-assert.equal(fs.existsSync('file2'), false);
-assert.equal(fs.existsSync('t/file1'), true);
-assert.equal(fs.existsSync('t/file2'), true);
+assert.equal(existsSync('file1'), false);
+assert.equal(existsSync('file2'), false);
+assert.equal(existsSync('t/file1'), true);
+assert.equal(existsSync('t/file2'), true);
 shell.mv('t/*', '.'); // revert
-assert.equal(fs.existsSync('file1'), true);
-assert.equal(fs.existsSync('file2'), true);
+assert.equal(existsSync('file1'), true);
+assert.equal(existsSync('file2'), true);
 
 shell.mv('file*.js', 't'); // wildcard
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('file1.js'), false);
-assert.equal(fs.existsSync('file2.js'), false);
-assert.equal(fs.existsSync('t/file1.js'), true);
-assert.equal(fs.existsSync('t/file2.js'), true);
+assert.equal(existsSync('file1.js'), false);
+assert.equal(existsSync('file2.js'), false);
+assert.equal(existsSync('t/file1.js'), true);
+assert.equal(existsSync('t/file2.js'), true);
 shell.mv('t/*', '.'); // revert
-assert.equal(fs.existsSync('file1.js'), true);
-assert.equal(fs.existsSync('file2.js'), true);
+assert.equal(existsSync('file1.js'), true);
+assert.equal(existsSync('file2.js'), true);
 
 shell.mv('-f', 'file1', 'file2'); // dest exists, but -f given
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('file1'), false);
-assert.equal(fs.existsSync('file2'), true);
+assert.equal(existsSync('file1'), false);
+assert.equal(existsSync('file2'), true);
 
 shell.exit(123);

--- a/test/rm.js
+++ b/test/rm.js
@@ -3,6 +3,7 @@ var shell = require('..');
 var assert = require('assert'),
     path = require('path'),
     fs = require('fs');
+var existsSync = require('../src/existsSync');
 
 shell.config.silent = true;
 
@@ -24,7 +25,7 @@ assert.ok(shell.error());
 
 shell.rm('-@', 'resources/file1'); // invalid option
 assert.ok(shell.error());
-assert.equal(fs.existsSync('resources/file1'), true);
+assert.equal(existsSync('resources/file1'), true);
 
 //
 // Valids
@@ -36,55 +37,55 @@ assert.equal(shell.error(), null);
 
 // simple rm
 shell.cp('-f', 'resources/file1', 'tmp/file1');
-assert.equal(fs.existsSync('tmp/file1'), true);
+assert.equal(existsSync('tmp/file1'), true);
 shell.rm('tmp/file1');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/file1'), false);
+assert.equal(existsSync('tmp/file1'), false);
 
 // recursive dir removal - small-caps '-r'
 shell.mkdir('-p', 'tmp/a/b/c');
-assert.equal(fs.existsSync('tmp/a/b/c'), true);
+assert.equal(existsSync('tmp/a/b/c'), true);
 shell.rm('-rf', 'tmp/a');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/a'), false);
+assert.equal(existsSync('tmp/a'), false);
 
 // recursive dir removal - capital '-R'
 shell.mkdir('-p', 'tmp/a/b/c');
-assert.equal(fs.existsSync('tmp/a/b/c'), true);
+assert.equal(existsSync('tmp/a/b/c'), true);
 shell.rm('-Rf', 'tmp/a');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/a'), false);
+assert.equal(existsSync('tmp/a'), false);
 
 // recursive dir removal - absolute path
 shell.mkdir('-p', 'tmp/a/b/c');
-assert.equal(fs.existsSync('tmp/a/b/c'), true);
+assert.equal(existsSync('tmp/a/b/c'), true);
 shell.rm('-Rf', path.resolve('./tmp/a'));
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/a'), false);
+assert.equal(existsSync('tmp/a'), false);
 
 // wildcard
 shell.cp('-f', 'resources/file*', 'tmp');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/file1'), true);
-assert.equal(fs.existsSync('tmp/file2'), true);
-assert.equal(fs.existsSync('tmp/file1.js'), true);
-assert.equal(fs.existsSync('tmp/file2.js'), true);
+assert.equal(existsSync('tmp/file1'), true);
+assert.equal(existsSync('tmp/file2'), true);
+assert.equal(existsSync('tmp/file1.js'), true);
+assert.equal(existsSync('tmp/file2.js'), true);
 shell.rm('tmp/file*');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/file1'), false);
-assert.equal(fs.existsSync('tmp/file2'), false);
-assert.equal(fs.existsSync('tmp/file1.js'), false);
-assert.equal(fs.existsSync('tmp/file2.js'), false);
+assert.equal(existsSync('tmp/file1'), false);
+assert.equal(existsSync('tmp/file2'), false);
+assert.equal(existsSync('tmp/file1.js'), false);
+assert.equal(existsSync('tmp/file2.js'), false);
 
 // recursive dir removal
 shell.mkdir('-p', 'tmp/a/b/c');
 shell.mkdir('-p', 'tmp/b');
 shell.mkdir('-p', 'tmp/c');
 shell.mkdir('-p', 'tmp/.hidden');
-assert.equal(fs.existsSync('tmp/a/b/c'), true);
-assert.equal(fs.existsSync('tmp/b'), true);
-assert.equal(fs.existsSync('tmp/c'), true);
-assert.equal(fs.existsSync('tmp/.hidden'), true);
+assert.equal(existsSync('tmp/a/b/c'), true);
+assert.equal(existsSync('tmp/b'), true);
+assert.equal(existsSync('tmp/c'), true);
+assert.equal(existsSync('tmp/.hidden'), true);
 shell.rm('-rf', 'tmp/*');
 assert.equal(shell.error(), null);
 var contents = fs.readdirSync('tmp');
@@ -96,10 +97,10 @@ shell.mkdir('-p', 'tmp/a/b/c');
 shell.mkdir('-p', 'tmp/b');
 shell.mkdir('-p', 'tmp/c');
 shell.mkdir('-p', 'tmp/.hidden');
-assert.equal(fs.existsSync('tmp/a/b/c'), true);
-assert.equal(fs.existsSync('tmp/b'), true);
-assert.equal(fs.existsSync('tmp/c'), true);
-assert.equal(fs.existsSync('tmp/.hidden'), true);
+assert.equal(existsSync('tmp/a/b/c'), true);
+assert.equal(existsSync('tmp/b'), true);
+assert.equal(existsSync('tmp/c'), true);
+assert.equal(existsSync('tmp/.hidden'), true);
 shell.rm('-rf', 'tmp/*', 'tmp/.*');
 assert.equal(shell.error(), null);
 var contents = fs.readdirSync('tmp');
@@ -110,10 +111,10 @@ shell.mkdir('-p', 'tmp/a/b/c');
 shell.mkdir('-p', 'tmp/b');
 shell.mkdir('-p', 'tmp/c');
 shell.mkdir('-p', 'tmp/.hidden');
-assert.equal(fs.existsSync('tmp/a/b/c'), true);
-assert.equal(fs.existsSync('tmp/b'), true);
-assert.equal(fs.existsSync('tmp/c'), true);
-assert.equal(fs.existsSync('tmp/.hidden'), true);
+assert.equal(existsSync('tmp/a/b/c'), true);
+assert.equal(existsSync('tmp/b'), true);
+assert.equal(existsSync('tmp/c'), true);
+assert.equal(existsSync('tmp/.hidden'), true);
 shell.rm('-rf', ['tmp/*', 'tmp/.*']);
 assert.equal(shell.error(), null);
 var contents = fs.readdirSync('tmp');
@@ -124,7 +125,7 @@ shell.mkdir('-p', 'tmp/readonly');
 'asdf'.to('tmp/readonly/file1');
 fs.chmodSync('tmp/readonly/file1', '0444'); // -r--r--r--
 shell.rm('tmp/readonly/file1');
-assert.equal(fs.existsSync('tmp/readonly/file1'), true); // bash's rm always asks before removing read-only files
+assert.equal(existsSync('tmp/readonly/file1'), true); // bash's rm always asks before removing read-only files
                                                          // here we just assume "no"
 
 // removal of a read-only file (forced)
@@ -132,7 +133,7 @@ shell.mkdir('-p', 'tmp/readonly');
 'asdf'.to('tmp/readonly/file2');
 fs.chmodSync('tmp/readonly/file2', '0444'); // -r--r--r--
 shell.rm('-f', 'tmp/readonly/file2');
-assert.equal(fs.existsSync('tmp/readonly/file2'), false);
+assert.equal(existsSync('tmp/readonly/file2'), false);
 
 // removal of a tree containing read-only files (unforced)
 shell.mkdir('-p', 'tmp/tree2');
@@ -140,8 +141,8 @@ shell.mkdir('-p', 'tmp/tree2');
 'asdf'.to('tmp/tree2/file2');
 fs.chmodSync('tmp/tree2/file1', '0444'); // -r--r--r--
 shell.rm('-r', 'tmp/tree2');
-assert.equal(fs.existsSync('tmp/tree2/file1'), true);
-assert.equal(fs.existsSync('tmp/tree2/file2'), false);
+assert.equal(existsSync('tmp/tree2/file1'), true);
+assert.equal(existsSync('tmp/tree2/file2'), false);
 
 // removal of a tree containing read-only files (forced)
 shell.mkdir('-p', 'tmp/tree');
@@ -149,7 +150,7 @@ shell.mkdir('-p', 'tmp/tree');
 'asdf'.to('tmp/tree/file2');
 fs.chmodSync('tmp/tree/file1', '0444'); // -r--r--r--
 shell.rm('-rf', 'tmp/tree');
-assert.equal(fs.existsSync('tmp/tree'), false);
+assert.equal(existsSync('tmp/tree'), false);
 
 // removal of a sub-tree containing read-only and hidden files - rm('dir/*')
 shell.mkdir('-p', 'tmp/tree3');
@@ -175,14 +176,14 @@ fs.chmodSync('tmp/tree4/file', '0444'); // -r--r--r--
 fs.chmodSync('tmp/tree4/subtree/file', '0444'); // -r--r--r--
 fs.chmodSync('tmp/tree4/.hidden/file', '0444'); // -r--r--r--
 shell.rm('-rf', 'tmp/tree4'); // erase dir contents
-assert.equal(fs.existsSync('tmp/tree4'), false);
+assert.equal(existsSync('tmp/tree4'), false);
 
 // remove symbolic link to a dir
 shell.rm('-rf', 'tmp');
 shell.cp('-R', 'resources/rm', 'tmp');
 shell.rm('-f', 'tmp/rm/link_to_a_dir');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync('tmp/rm/link_to_a_dir'), false);
-assert.equal(fs.existsSync('tmp/rm/a_dir'), true);
+assert.equal(existsSync('tmp/rm/link_to_a_dir'), false);
+assert.equal(existsSync('tmp/rm/a_dir'), true);
 
 shell.exit(123);

--- a/test/sed.js
+++ b/test/sed.js
@@ -1,7 +1,7 @@
 var shell = require('..');
 
-var assert = require('assert'),
-    fs = require('fs');
+var assert = require('assert');
+var existsSync = require('../src/existsSync');
 
 shell.config.silent = true;
 
@@ -21,7 +21,7 @@ assert.ok(shell.error());
 shell.sed(/asdf/g, 'nada'); // too few args
 assert.ok(shell.error());
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(existsSync('/asdfasdf'), false); // sanity check
 shell.sed(/asdf/g, 'nada', '/asdfasdf'); // no such file
 assert.ok(shell.error());
 

--- a/test/tempdir.js
+++ b/test/tempdir.js
@@ -1,7 +1,7 @@
 var shell = require('..');
 
-var assert = require('assert'),
-    fs = require('fs');
+var assert = require('assert');
+var existsSync = require('../src/existsSync');
 
 shell.config.silent = true;
 
@@ -14,6 +14,6 @@ shell.mkdir('tmp');
 
 var tmp = shell.tempdir();
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync(tmp), true);
+assert.equal(existsSync(tmp), true);
 
 shell.exit(123);

--- a/test/to.js
+++ b/test/to.js
@@ -1,7 +1,7 @@
 var shell = require('..');
 
-var assert = require('assert'),
-    fs = require('fs');
+var assert = require('assert');
+var existsSync = require('../src/existsSync');
 
 shell.config.silent = true;
 
@@ -15,7 +15,7 @@ shell.mkdir('tmp');
 'hello world'.to();
 assert.ok(shell.error());
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(existsSync('/asdfasdf'), false); // sanity check
 'hello world'.to('/asdfasdf/file');
 assert.ok(shell.error());
 

--- a/test/toEnd.js
+++ b/test/toEnd.js
@@ -1,7 +1,7 @@
 var shell = require('..');
 
-var assert = require('assert'),
-    fs = require('fs');
+var assert = require('assert');
+var existsSync = require('../src/existsSync');
 
 shell.config.silent = true;
 
@@ -15,15 +15,15 @@ shell.mkdir('tmp');
 'hello world'.toEnd();
 assert.ok(shell.error());
 
-assert.equal(fs.existsSync('/asdfasdf'), false); // sanity check
+assert.equal(existsSync('/asdfasdf'), false); // sanity check
 assert.ok(shell.error());
 //
 // Valids
 //
 
-assert.equal(fs.existsSync('tmp/toEnd1'), false); //Check file toEnd() creates does not already exist
+assert.equal(existsSync('tmp/toEnd1'), false); //Check file toEnd() creates does not already exist
 'hello '.toEnd('tmp/toEnd1');
-assert.equal(fs.existsSync('tmp/toEnd1'), true); //Check that file was created
+assert.equal(existsSync('tmp/toEnd1'), true); //Check that file was created
 'world'.toEnd('tmp/toEnd1'); //Write some more to the file
 var result = shell.cat('tmp/toEnd1');
 assert.equal(shell.error(), null);

--- a/test/which.js
+++ b/test/which.js
@@ -1,7 +1,7 @@
 var shell = require('..');
 
-var assert = require('assert'),
-    fs = require('fs');
+var assert = require('assert');
+var existsSync = require('../src/existsSync');
 
 shell.config.silent = true;
 
@@ -25,6 +25,6 @@ assert.equal(result, null);
 
 var result = shell.which('node');
 assert.equal(shell.error(), null);
-assert.equal(fs.existsSync(result), true);
+assert.equal(existsSync(result), true);
 
 shell.exit(123);


### PR DESCRIPTION
This change makes all the tests pass in `node` `0.6` - which also means that any dependents of it won't automatically be broken in `v0.6` :-)