### PR TITLE
Preserve supplied options.async

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -165,7 +165,7 @@ function _exec(command, options, callback) {
 
   // Callback is defined with options.
   if (typeof options === 'object' && typeof callback === 'function') {
-    options.async = true;
+    options.async = options.async || true;
   }
 
   options = common.extend({


### PR DESCRIPTION
Hi there,

Say, I ran this code:
```js
var sh = require('shelljs');

sh.exec("sleep 0.5", {async: false}, function() {
    sh.echo("print first");
});

sh.echo("print last");
```

...as output,  I will get:
```
print last
print first
```

Your documentation on [shelljs.org](http://documentup.com/arturadib/shelljs#command-reference/exec-command-options-callback) seems to imply that if you pass in an `{async:false}` as options, you still get to run code synchronously.

Cheers. M.
