### PR TITLE
Breaking: Allow -- as args separators (fixes #188)

### DIFF
--- a/make.js
+++ b/make.js
@@ -3,9 +3,18 @@ require('./global');
 global.config.fatal = true;
 global.target = {};
 
+var args = process.argv.slice(2),
+  targetArgs,
+  dashesLoc = args.indexOf('--');
+
+// split args, everything after -- if only for targets
+if (dashesLoc > -1) {
+  targetArgs = args.slice(dashesLoc + 1, args.length);
+  args = args.slice(0, dashesLoc);
+}
+
 // This ensures we only execute the script targets after the entire script has
 // been evaluated
-var args = process.argv.slice(2);
 setTimeout(function() {
   var t;
 
@@ -21,8 +30,8 @@ setTimeout(function() {
     (function(t, oldTarget){
 
       // Wrap it
-      global.target[t] = function(force) {
-        if (oldTarget.done && !force)
+      global.target[t] = function() {
+        if (oldTarget.done)
           return;
         oldTarget.done = true;
         return oldTarget.apply(oldTarget, arguments);
@@ -35,13 +44,13 @@ setTimeout(function() {
   if (args.length > 0) {
     args.forEach(function(arg) {
       if (arg in global.target)
-        global.target[arg]();
+        global.target[arg](targetArgs);
       else {
         console.log('no such target: ' + arg);
       }
     });
   } else if ('all' in global.target) {
-    global.target.all();
+    global.target.all(targetArgs);
   }
 
 }, 0);


### PR DESCRIPTION
This implements a change that allows `--` to indicate arguments to be passed to `make` targets. Basically, you can do this:

```js
target.foo = function(args) {

};
```

And `args` will be everything after the `--` on the command line, so for example:

```
$ node Makefile.js foo -- bar baz
```

`args` in the previous code will be `['bar', 'baz']`.

I noticed there's a `force` argument for targets, but I couldn't find anywhere it's documented or used. So, I moved it to be the second argument as it seems mostly unused at the moment.

Other caveats:

1. It appears there aren't any tests for `make.js`, so I didn't know if it's okay to just make changes. I did test it locally with an example file and it worked
1. `npm test` fails for me (I'm on Windows using Git Bash) and I couldn't figure out how to get it to run, so I'm not really sure about this change.

@arturadib let me know if this is okay or if you'd like other changes.