### PR TITLE
prevent internal error: write after end

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -59,8 +59,8 @@ function execSync(cmd, opts) {
       "  fs.writeFileSync('"+escape(codeFile)+"', err ? err.code.toString() : '0');",
       "});",
       "var stdoutStream = fs.createWriteStream('"+escape(stdoutFile)+"');",
-      "childProcess.stdout.pipe(stdoutStream);",
-      "childProcess.stderr.pipe(stdoutStream);",
+      "childProcess.stdout.pipe(stdoutStream, {end: false});",
+      "childProcess.stderr.pipe(stdoutStream, {end: false});",
       "childProcess.stdout.pipe(process.stdout);",
       "childProcess.stderr.pipe(process.stderr);"
     ].join('\n');


### PR DESCRIPTION
fixes #206 

Was unable to write a reliable test but the following failed about half time without the change and did not fail with the change

```coffee
shell.exec('git checkout -')
```

I'm convinced this is the appropriate fix based on the [documentation](https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options) as we are piping two readable streams to a writeable stream and if one ends and the other writes later we get a "write after end". The ends of the std streams does not appear to be consistent. 