### PR TITLE
Memoized the result of target invocation

### DIFF
--- a/make.js
+++ b/make.js
@@ -31,10 +31,11 @@ setTimeout(function() {
 
       // Wrap it
       global.target[t] = function() {
-        if (oldTarget.done)
-          return;
-        oldTarget.done = true;
-        return oldTarget.apply(oldTarget, arguments);
+        if (!oldTarget.done){
+          oldTarget.done = true;
+          oldTarget.result = oldTarget.apply(oldTarget, arguments);
+        }
+        return oldTarget.result;
       };
 
     })(t, global.target[t]);


### PR DESCRIPTION
For a current make script I was unable to use promises as the task had previously ran.
This commit it makes it so the targets still return a result even if they have been ran. This makes it so that the promises can still be used.