### PR TITLE
Manually closing streams

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -62,7 +62,9 @@ function execSync(cmd, opts) {
       "childProcess.stdout.pipe(stdoutStream, {end: false});",
       "childProcess.stderr.pipe(stdoutStream, {end: false});",
       "childProcess.stdout.pipe(process.stdout);",
-      "childProcess.stderr.pipe(process.stderr);"
+      "childProcess.stderr.pipe(process.stderr);",
+      "process.stdout.on('end', function(){ stdoutStream.end(); });",
+      "process.stderr.on('end', function(){ stdoutStream.end(); });"
     ].join('\n');
 
     fs.writeFileSync(scriptFile, script);

--- a/src/exec.js
+++ b/src/exec.js
@@ -63,8 +63,10 @@ function execSync(cmd, opts) {
       "childProcess.stderr.pipe(stdoutStream, {end: false});",
       "childProcess.stdout.pipe(process.stdout);",
       "childProcess.stderr.pipe(process.stderr);",
-      "process.stdout.on('end', function(){ stdoutStream.end(); });",
-      "process.stderr.on('end', function(){ stdoutStream.end(); });"
+      "var stdoutEnded = false, stderrEnded = false;",
+      "function tryClosing(){ if(stdoutEnded && stderrEnded){ stdoutStream.end(); } }",
+      "childProcess.stdout.on('end', function(){ stdoutEnded = true; tryClosing(); });",
+      "childProcess.stderr.on('end', function(){ stderrEnded = true; tryClosing(); });"
     ].join('\n');
 
     fs.writeFileSync(scriptFile, script);


### PR DESCRIPTION
Solves the stream closing issue introduced by pull [#214](https://github.com/arturadib/shelljs/pull/214).

According to the [Node Docs](https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options), `process.stderr` and `process.stdout` are closed when the process exits - we can listen to this and close the `stdoutStream` accordingly