### PR TITLE
Fixes an issue with multi-symbolic mode specification (ie a-rwx,u+rw)

### DIFF
--- a/src/chmod.js
+++ b/src/chmod.js
@@ -185,7 +185,7 @@ function _chmod(options, mode, filePattern) {
               log(file + ' -> ' + newPerms.toString(8));
             }
             fs.chmodSync(file, newPerms);
-            //perms = newPerms; // for the next round of changes!
+            perms = newPerms; // for the next round of changes!
           }
         }
         else {

--- a/src/chmod.js
+++ b/src/chmod.js
@@ -185,6 +185,7 @@ function _chmod(options, mode, filePattern) {
               log(file + ' -> ' + newPerms.toString(8));
             }
             fs.chmodSync(file, newPerms);
+            //perms = newPerms; // for the next round of changes!
           }
         }
         else {

--- a/test/chmod.js
+++ b/test/chmod.js
@@ -77,4 +77,48 @@ assert.equal(fs.statSync('resources/chmod/b/a').mode & parseInt('700', 8), parse
 shell.chmod('-R', 'u+w', 'resources/chmod/a/b');
 fs.unlinkSync('resources/chmod/a/b/c/link');
 
+// Test combinations
+shell.chmod('a-rwx', 'resources/chmod/file1');
+assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('000', 8), parseInt('000', 8));
+shell.chmod('644', 'resources/chmod/file1');
+
+shell.chmod('a-rwx,u+r', 'resources/chmod/file1');
+assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('400', 8), parseInt('400', 8));
+shell.chmod('644', 'resources/chmod/file1');
+
+shell.chmod('a-rwx,u+rw', 'resources/chmod/file1');
+assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('600', 8), parseInt('600', 8));
+shell.chmod('644', 'resources/chmod/file1');
+
+shell.chmod('a-rwx,u+rwx', 'resources/chmod/file1');
+assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('700', 8), parseInt('700', 8));
+shell.chmod('644', 'resources/chmod/file1');
+
+shell.chmod('000', 'resources/chmod/file1');
+shell.chmod('u+rw', 'resources/chmod/file1');
+assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('600', 8), parseInt('600', 8));
+shell.chmod('644', 'resources/chmod/file1');
+
+shell.chmod('000', 'resources/chmod/file1');
+shell.chmod('u+wx', 'resources/chmod/file1');
+assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('300', 8), parseInt('300', 8));
+shell.chmod('644', 'resources/chmod/file1');
+
+shell.chmod('000', 'resources/chmod/file1');
+shell.chmod('u+r,g+w,o+x', 'resources/chmod/file1');
+assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('421', 8), parseInt('421', 8));
+shell.chmod('644', 'resources/chmod/file1');
+
+shell.chmod('000', 'resources/chmod/file1');
+shell.chmod('u+rw,g+wx', 'resources/chmod/file1');
+assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('462', 8), parseInt('630', 8));
+shell.chmod('644', 'resources/chmod/file1');
+
+shell.chmod('700', 'resources/chmod/file1');
+shell.chmod('u-x,g+rw', 'resources/chmod/file1');
+assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('660', 8), parseInt('660', 8));
+shell.chmod('644', 'resources/chmod/file1');
+
+
+
 shell.exit(123);

--- a/test/chmod.js
+++ b/test/chmod.js
@@ -119,6 +119,12 @@ shell.chmod('u-x,g+rw', 'resources/chmod/file1');
 assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('660', 8), parseInt('660', 8));
 shell.chmod('644', 'resources/chmod/file1');
 
+shell.chmod('a-rwx,u+rw', 'resources/chmod/file1');
+assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('600', 8), parseInt('600', 8));
+shell.chmod('a-rwx,u+rw', 'resources/chmod/file1');
+assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('600', 8), parseInt('600', 8));
+shell.chmod('644', 'resources/chmod/file1');
+
 
 
 shell.exit(123);

--- a/test/chmod.js
+++ b/test/chmod.js
@@ -111,7 +111,7 @@ shell.chmod('644', 'resources/chmod/file1');
 
 shell.chmod('000', 'resources/chmod/file1');
 shell.chmod('u+rw,g+wx', 'resources/chmod/file1');
-assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('462', 8), parseInt('630', 8));
+assert.equal(fs.statSync('resources/chmod/file1').mode & parseInt('630', 8), parseInt('630', 8));
 shell.chmod('644', 'resources/chmod/file1');
 
 shell.chmod('700', 'resources/chmod/file1');


### PR DESCRIPTION
If you call:

shelljs.chmod('a-rwx,u+rw', 'file');
shelljs.chmod('a-rwx,u+rw', 'file');

Then the file will have no permissions (mode 000). This is because the permissions at the beginning of the second call are 600, and when the 'u+rw' is processed, it compares the final mode (600) with the original mode (now outdated due to 'a-rwx', but 600) and does not run the operation if they are the same.

This PR adds a few more multi-symbolic tests, and resets 'perms' to 'newPerms' after running fs.chmodSync() to allow examples like 'a-rwx,u+rw' to work correctly even if the original file permission was already set as desired.